### PR TITLE
Fix spelling mistake on DepthFirstSort mispelled as DephFirstSort

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -392,7 +392,7 @@ func (g *Graph) Run(ctx context.Context, opt *getoptions.GetOpt, args []string) 
 	}
 
 	// Check for cycles
-	_, err := g.DephFirstSort()
+	_, err := g.DepthFirstSort()
 	if err != nil {
 		return err
 	}
@@ -552,10 +552,10 @@ func skipParents(v *Vertex) {
 	}
 }
 
-// DephFirstSort - Returns a sorted list with the Vertices
+// DepthFirstSort - Returns a sorted list with the Vertices
 // https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
 // It returns ErrorGraphHasCycle is there are cycles.
-func (g *Graph) DephFirstSort() ([]*Vertex, error) {
+func (g *Graph) DepthFirstSort() ([]*Vertex, error) {
 	var err error
 
 	sorted := []*Vertex{}

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -72,7 +72,7 @@ func TestDag(t *testing.T) {
 		t.Errorf("Unexpected error: %s\n", err)
 	}
 
-	_, err = g.DephFirstSort()
+	_, err = g.DepthFirstSort()
 	if err != nil {
 		t.Errorf("Unexpected error: %s\n", err)
 	}
@@ -245,7 +245,7 @@ func TestCycle(t *testing.T) {
 
 	g.TaskDependensOn(g.Task("t1"), g.Task("t2"))
 	g.TaskDependensOn(g.Task("t2"), g.Task("t1"))
-	_, err := g.DephFirstSort()
+	_, err := g.DepthFirstSort()
 	if err == nil || !errors.Is(err, ErrorGraphHasCycle) {
 		t.Errorf("Wrong error: %s\n", err)
 	}


### PR DESCRIPTION
Hello David :). Was snooping around and saw a spelling mistake. Thought I'd go ahead and make a PR. Let me know if anything needs to be changed. 

I've run the tests locally and it looks good, and I've compiled some of your examples (dag, mygit) and they seem to work. 